### PR TITLE
use full path to config file

### DIFF
--- a/jobstats
+++ b/jobstats
@@ -17,6 +17,7 @@ import shutil        # Get the terminal size
 import configparser  # Read args from config file
 import statistics    # Calculating median
 import shlex         # Ensure strings sent to bash are properly escaped
+import os
 
 
 class Colors:
@@ -150,7 +151,8 @@ def timeStringToSeconds(timeString):
 def main():
     # Read in config args
     config = configparser.ConfigParser()
-    config.read('jobstats-config.ini')
+    configFilePath = (os.path.dirname(__file__) + str('/jobstats-config.ini'))
+    config.read(configFilePath)
     SHOW_JOB_CHILDREN  = config['DEFAULTS']['SHOW_JOB_CHILDREN'] == 'True' 
     MEMORY_WEIGHT      = int(config['DEFAULTS']['MEMORY_WEIGHT'])
     CPU_WEIGHT         = int(config['DEFAULTS']['CPU_WEIGHT'])


### PR DESCRIPTION
I tried to add this utility to my cluster as a module but I noticed that I have to execute it from the installation directory so it can find the config file. I was getting this error when executing it from a different directory

```
Traceback (most recent call last):
  File "/scicore/home/scicore/escobar/github-repos/jobstats/jobstats", line 680, in <module>
    main()
  File "/scicore/home/scicore/escobar/github-repos/jobstats/jobstats", line 154, in main
    SHOW_JOB_CHILDREN  = config['DEFAULTS']['SHOW_JOB_CHILDREN'] == 'True' 
  File "/scicore/soft/apps/Python/3.5.2-goolf-1.7.20/lib/python3.5/configparser.py", line 956, in __getitem__
    raise KeyError(key)
KeyError: 'DEFAULTS'
```

This small fix allows to execute it from a different folder