### PR TITLE
jobsum --> cpuhours for user_eff and bugfix in group_efficiency

### DIFF
--- a/jobstats/group_efficiency
+++ b/jobstats/group_efficiency
@@ -430,6 +430,7 @@ def main():
     
     cursor = cnx.cursor()
 
+    data = []
     if ALL_ACCOUNTS:
         accounts = getSlurmAccounts()
         group_efficiency=""
@@ -556,7 +557,6 @@ def main():
             key=str(key)+field1
             tuples.update({key:(field1,field2,field3,field4,field5)})
         sortedlist=sorted(tuples.items(),key=operator.itemgetter(0),reverse=True)
-        data=[]
         
         #take sorted list from dictionary and put them into a list
         for elem in sortedlist:
@@ -690,7 +690,6 @@ def main():
                 key+=100
                 tuples.update({key:(field1,field2,field3,field4,field5)})
             sortedlist=sorted(tuples.items(),key=operator.itemgetter(0),reverse=True)
-            data=[]
             for elem in sortedlist:
                 
                 elem=list(elem)

--- a/jobstats/user_efficiency
+++ b/jobstats/user_efficiency
@@ -47,12 +47,11 @@ def formatRow(fmtString, strList, maxLen):
     return fmtString.format(strList[0], strList[1], strList[2], strList[3],
                             strList[4], strList[5], strList[6])
 
-def createTable(fields, data, totalWidth, number, parsable):
+def createTable(data, totalWidth, number, parsable):
     """
     Desc: Print a table with job efficiency information
 
     Args:
-        fields (list of strings): list of keys to extract from the data dict, order matters
         data (dict): a dictionary where each key is a unique uid, values are efficiency info
         totalWidth (string): specifies max length of each row when parsable is False
         number (int): Maximum number of rows to display in table, -1 specifies all
@@ -72,8 +71,8 @@ def createTable(fields, data, totalWidth, number, parsable):
         raise Exception("totalWidth = " + str(totalWidth))
 
     # assuming that we always want to print all metrics
-    keys = ['rank', 'account', 'cores', 'memory', 'time', 'jobs', 'total']
-    headers = ["rank", "account", "cores", "memory", "time limit", "jobs", "total efficiency"]
+    keys = ['rank', 'account', 'cores', 'memory', 'time', 'cpuhours', 'total']
+    headers = ["rank", "account", "cores", "memory", "time limit", "cpuhours", "total efficiency"]
     maxLen = []
     if totalWidth < 40:
         totalWidth = 40 # ignoring requests of less than 40 units, you won't get a useful table
@@ -135,7 +134,7 @@ def getTimeSlice(cursor, fromDate, toDate):
     """
     data = dict()
 
-    query =  'SELECT username,memoryreq,memoryuse,idealcpu,cputime,tlimitreq,tlimituse,jobsum'
+    query =  'SELECT username,memoryreq,memoryuse,idealcpu,cputime,tlimitreq,tlimituse'
     query += ' FROM jobs WHERE date >= %s AND date <= %s'
 
     args = [fromDate, toDate]
@@ -143,15 +142,14 @@ def getTimeSlice(cursor, fromDate, toDate):
     cursor.execute(query, tuple(args))
 
     # add together all stats for each unique user
-    for username, memory_req, memory_use, ideal_cpu, cpu_time, tlimit_req, tlimit_use, jobsum in cursor:
+    for username, memory_req, memory_use, ideal_cpu, cpu_time, tlimit_req, tlimit_use in cursor:
         if username not in data:
             data[username] = {'memory-req': memory_req if memory_req else 0,
                               'memory-use': memory_use if memory_use else 0,
                               'ideal-cpu' : ideal_cpu if ideal_cpu else 0,
                               'cpu-time'  : cpu_time if cpu_time else 0,
                               'tlimit-req': tlimit_req if tlimit_req else 0,
-                              'tlimit-use': tlimit_use if tlimit_use else 0,
-                              'jobs'      : jobsum if jobsum else 0}
+                              'tlimit-use': tlimit_use if tlimit_use else 0}
         else:
             data[username]['memory-req'] += memory_req if memory_req else 0
             data[username]['memory-use'] += memory_use if memory_use else 0
@@ -159,13 +157,13 @@ def getTimeSlice(cursor, fromDate, toDate):
             data[username]['cpu-time']   += cpu_time if cpu_time else 0
             data[username]['tlimit-req'] += tlimit_req if tlimit_req else 0
             data[username]['tlimit-use'] += tlimit_use if tlimit_use else 0
-            data[username]['jobs']       += jobsum if jobsum else 0
 
     result = []
     for username in data:
         # doppler refers to cpu effiency as "cores" efficiency
         # replace 0 eff values with '-' in output
         # 0 eff values mean the job failed
+        
         core_req = data[username]['ideal-cpu'];
         core_used = data[username]['cpu-time'];
         core_eff = 100 * core_used / core_req if core_req != 0 else 0.0
@@ -178,23 +176,28 @@ def getTimeSlice(cursor, fromDate, toDate):
         time_used = data[username]['tlimit-use']
         time_eff = 100 * time_used / time_req if time_req != 0 else 0.0
 
+        cpuhours = None
+        
         if core_used == 0 and core_req == 0: # should only be True in single-core case
             core_eff = time_eff
-        
+            cpuhours = float(data[username]['tlimit-use']) / 3600
+        else:
+            cpuhours = float(data[username]['cpu-time']) / 3600
+
         total_eff = (core_eff + memory_eff + time_eff) / 3
-        result.append({'account': username,
-                       'cores'  : round(core_eff, 2),
-                       'memory' : round(memory_eff, 2),
-                       'time'   : round(time_eff, 2),
-                       'jobs'   : data[username]['jobs'],
-                       'total'  : round(total_eff, 2)})
+        result.append({'account'  : username,
+                       'cores'    : round(core_eff, 2),
+                       'memory'   : round(memory_eff, 2),
+                       'time'     : round(time_eff, 2),
+                       'cpuhours' : round(cpuhours, 2),
+                       'total'    : round(total_eff, 2)})
 
     return result # returning a list to be sorted later
     
 def main():
     parser = argparse.ArgumentParser(description="Get user efficiency statistics")
     parser.add_argument("-e", "--metric", type=str,
-                        choices=['cores', 'memory', 'time', 'total', 'jobs'],
+                        choices=['cores', 'memory', 'time', 'total', 'cpuhours'],
                         default='total', help="metric to sort by")
     parser.add_argument("-w", "--weekly", action="store_true",
                         help="select weekly time interval (default)")
@@ -268,11 +271,10 @@ def main():
     COLUMN_MAX         = config['DEFAULTS']['COLUMN_MAX']
     if(args.col_size is not None):
         COLUMN_MAX = args.col_size
-    fields = ["rank", "account", "cores", "memory", "time limit", "jobs", "total efficiency"]
     if args.all_rows == False:
-        createTable(fields, data, COLUMN_MAX, args.number, args.parsable)
+        createTable(data, COLUMN_MAX, args.number, args.parsable)
     else:
-        createTable(fields, data, COLUMN_MAX, -1, args.parsable)
+        createTable(data, COLUMN_MAX, -1, args.parsable)
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
When an account has no data for a time slice we get an UnboundLocalError in group_efficiency. I just assign the data list variable from main higher up in the code.

A couple examples displaying cpuhours:

```
jfg95@wind.nauhpc:~/hpc $ ./user_efficiency --metric cpuhours
rank   account   cores   memory   time limit   cpuhours   total efficiency
============================================================================
1      ksg225    98.38   82.1     64.06        83715.89   81.51           
41     sp2358    13.31   38.55    13.31        20126.57   21.72           
2      jb3729    97.36   35.1     97.36        19717.51   76.61           
17     mkf58     43.35   22.01    43.35        19502.24   36.23           
16     ak2223    34.06   48.4     34.06        8941.2     38.84           
4      cw997     56.91   90.23    56.91        5425.76    68.02           
18     mib75     60.84   12.64    29.37        3499.64    34.28           
38     af2358    29.79   10.05    29.79        3170.51    23.21           
54     pp58      16.2    7.79     23.5         2372.03    15.83           
14     sm3544    72.99   16.92    37.16        1654.64    42.36           
jfg95@wind.nauhpc:~/hpc $ ./user_efficiency --metric cpuhours --ascending
rank   account   cores   memory   time limit   cpuhours   total efficiency
============================================================================
95     af2344    0.08    0.0      0.08         0.0        0.06            
90     pr446     1.0     0.0      1.0          0.0        0.67            
96     sm2956    0.04    0.0      0.04         0.01       0.03            
94     ak2296    0.11    0.0      0.11         0.01       0.07            
93     mk959     0.18    0.0      0.18         0.01       0.12            
91     krc395    0.31    0.0      0.31         0.01       0.2             
80     ms3459    2.83    4.05     2.83         0.01       3.24            
92     glt47     0.22    0.15     0.22         0.02       0.2             
89     dg856     1.32    0.14     1.32         0.02       0.92            
27     ig299     5.66    8.68     72.5         0.02       28.95           
jfg95@wind.nauhpc:~/hpc $
```