### PR TITLE
user_eff matches doppler and a couple bug fixes

### DIFF
--- a/jobstats/group_efficiency
+++ b/jobstats/group_efficiency
@@ -430,6 +430,7 @@ def main():
     
     cursor = cnx.cursor()
 
+    data = []
     if ALL_ACCOUNTS:
         accounts = getSlurmAccounts()
         group_efficiency=""
@@ -556,7 +557,6 @@ def main():
             key=str(key)+field1
             tuples.update({key:(field1,field2,field3,field4,field5)})
         sortedlist=sorted(tuples.items(),key=operator.itemgetter(0),reverse=True)
-        data=[]
         
         #take sorted list from dictionary and put them into a list
         for elem in sortedlist:
@@ -690,7 +690,6 @@ def main():
                 key+=100
                 tuples.update({key:(field1,field2,field3,field4,field5)})
             sortedlist=sorted(tuples.items(),key=operator.itemgetter(0),reverse=True)
-            data=[]
             for elem in sortedlist:
                 
                 elem=list(elem)

--- a/jobstats/jobstats
+++ b/jobstats/jobstats
@@ -414,6 +414,9 @@ def main():
         jobEfficiency = [None, None, None]  # Mem, cpu, time
         jobString = ''
 
+        if i[3] is None: # maxRSS may be None while job is executing
+            i[3] = '0'
+
         for valIndex, valString in enumerate(i):
             # Attempt to assess quality of the current value
             rating = ''

--- a/jobstats/user_efficiency
+++ b/jobstats/user_efficiency
@@ -47,12 +47,11 @@ def formatRow(fmtString, strList, maxLen):
     return fmtString.format(strList[0], strList[1], strList[2], strList[3],
                             strList[4], strList[5], strList[6])
 
-def createTable(fields, data, totalWidth, number, parsable):
+def createTable(data, totalWidth, number, parsable):
     """
     Desc: Print a table with job efficiency information
 
     Args:
-        fields (list of strings): list of keys to extract from the data dict, order matters
         data (dict): a dictionary where each key is a unique uid, values are efficiency info
         totalWidth (string): specifies max length of each row when parsable is False
         number (int): Maximum number of rows to display in table, -1 specifies all
@@ -72,8 +71,8 @@ def createTable(fields, data, totalWidth, number, parsable):
         raise Exception("totalWidth = " + str(totalWidth))
 
     # assuming that we always want to print all metrics
-    keys = ['rank', 'account', 'cores', 'memory', 'time', 'jobs', 'total']
-    headers = ["rank", "account", "cores", "memory", "time limit", "jobs", "total efficiency"]
+    keys = ['rank', 'account', 'cores', 'memory', 'time', 'cpuhours', 'total']
+    headers = ["rank", "account", "cores", "memory", "time limit", "cpuhours", "total efficiency"]
     maxLen = []
     if totalWidth < 40:
         totalWidth = 40 # ignoring requests of less than 40 units, you won't get a useful table
@@ -135,7 +134,7 @@ def getTimeSlice(cursor, fromDate, toDate):
     """
     data = dict()
 
-    query =  'SELECT username,memoryreq,memoryuse,idealcpu,cputime,tlimitreq,tlimituse,jobsum'
+    query =  'SELECT username,memoryreq,memoryuse,idealcpu,cputime,tlimitreq,tlimituse'
     query += ' FROM jobs WHERE date >= %s AND date <= %s'
 
     args = [fromDate, toDate]
@@ -143,15 +142,14 @@ def getTimeSlice(cursor, fromDate, toDate):
     cursor.execute(query, tuple(args))
 
     # add together all stats for each unique user
-    for username, memory_req, memory_use, ideal_cpu, cpu_time, tlimit_req, tlimit_use, jobsum in cursor:
+    for username, memory_req, memory_use, ideal_cpu, cpu_time, tlimit_req, tlimit_use in cursor:
         if username not in data:
             data[username] = {'memory-req': memory_req if memory_req else 0,
                               'memory-use': memory_use if memory_use else 0,
                               'ideal-cpu' : ideal_cpu if ideal_cpu else 0,
                               'cpu-time'  : cpu_time if cpu_time else 0,
                               'tlimit-req': tlimit_req if tlimit_req else 0,
-                              'tlimit-use': tlimit_use if tlimit_use else 0,
-                              'jobs'      : jobsum if jobsum else 0}
+                              'tlimit-use': tlimit_use if tlimit_use else 0}
         else:
             data[username]['memory-req'] += memory_req if memory_req else 0
             data[username]['memory-use'] += memory_use if memory_use else 0
@@ -159,13 +157,13 @@ def getTimeSlice(cursor, fromDate, toDate):
             data[username]['cpu-time']   += cpu_time if cpu_time else 0
             data[username]['tlimit-req'] += tlimit_req if tlimit_req else 0
             data[username]['tlimit-use'] += tlimit_use if tlimit_use else 0
-            data[username]['jobs']       += jobsum if jobsum else 0
 
     result = []
     for username in data:
         # doppler refers to cpu effiency as "cores" efficiency
         # replace 0 eff values with '-' in output
         # 0 eff values mean the job failed
+        
         core_req = data[username]['ideal-cpu'];
         core_used = data[username]['cpu-time'];
         core_eff = 100 * core_used / core_req if core_req != 0 else 0.0
@@ -178,23 +176,28 @@ def getTimeSlice(cursor, fromDate, toDate):
         time_used = data[username]['tlimit-use']
         time_eff = 100 * time_used / time_req if time_req != 0 else 0.0
 
+        cpuhours = None
+        
         if core_used == 0 and core_req == 0: # should only be True in single-core case
             core_eff = time_eff
-        
+            cpuhours = float(data[username]['tlimit-use']) / 3600
+        else:
+            cpuhours = float(data[username]['cpu-time']) / 3600
+
         total_eff = (core_eff + memory_eff + time_eff) / 3
-        result.append({'account': username,
-                       'cores'  : round(core_eff, 2),
-                       'memory' : round(memory_eff, 2),
-                       'time'   : round(time_eff, 2),
-                       'jobs'   : data[username]['jobs'],
-                       'total'  : round(total_eff, 2)})
+        result.append({'account'  : username,
+                       'cores'    : round(core_eff, 2),
+                       'memory'   : round(memory_eff, 2),
+                       'time'     : round(time_eff, 2),
+                       'cpuhours' : round(cpuhours, 2),
+                       'total'    : round(total_eff, 2)})
 
     return result # returning a list to be sorted later
     
 def main():
     parser = argparse.ArgumentParser(description="Get user efficiency statistics")
     parser.add_argument("-e", "--metric", type=str,
-                        choices=['cores', 'memory', 'time', 'total', 'jobs'],
+                        choices=['cores', 'memory', 'time', 'total', 'cpuhours'],
                         default='total', help="metric to sort by")
     parser.add_argument("-w", "--weekly", action="store_true",
                         help="select weekly time interval (default)")
@@ -268,11 +271,10 @@ def main():
     COLUMN_MAX         = config['DEFAULTS']['COLUMN_MAX']
     if(args.col_size is not None):
         COLUMN_MAX = args.col_size
-    fields = ["rank", "account", "cores", "memory", "time limit", "jobs", "total efficiency"]
     if args.all_rows == False:
-        createTable(fields, data, COLUMN_MAX, args.number, args.parsable)
+        createTable(data, COLUMN_MAX, args.number, args.parsable)
     else:
-        createTable(fields, data, COLUMN_MAX, -1, args.parsable)
+        createTable(data, COLUMN_MAX, -1, args.parsable)
 
 if __name__ == '__main__':
     main()

--- a/jobstats/user_efficiency
+++ b/jobstats/user_efficiency
@@ -71,20 +71,27 @@ def createTable(data, totalWidth, number, parsable):
         raise Exception("totalWidth = " + str(totalWidth))
 
     # assuming that we always want to print all metrics
-    keys = ['rank', 'account', 'cores', 'memory', 'time', 'cpuhours', 'total']
-    headers = ["rank", "account", "cores", "memory", "time limit", "cpuhours", "total efficiency"]
+    keys = ['rank', 'account', 'cores', 'memory', 'time', 'core hours', 'total']
+    headers = ["rank", "account", "cores", "memory", "time limit", "core hours", "total efficiency"]
     maxLen = []
     if totalWidth < 40:
         totalWidth = 40 # ignoring requests of less than 40 units, you won't get a useful table
     
     for header in headers:
         maxLen.append(len(header))
+
     if not parsable:
         if number == -1:
             number = len(data)
         # find longest cell for each column, update maxLen
         i = 0
         while i < number and i < len(data):
+            # format floats here
+            # change format of 'core hours'
+            if(data[i]['core hours'] >= 1000.0):
+                data[i]['core hours'] = '{:.1f}'.format(round(data[i]['core hours'] / 1000.0, 1)) + "K"
+            else:
+                data[i]['core hours'] = '{:.1f}'.format(data[i]['core hours'])
             for j in range(len(keys)):
                 if(len(str(data[i][keys[j]])) > maxLen[j]):
                     maxLen[j] = len(str(data[i][keys[j]]))
@@ -161,8 +168,6 @@ def getTimeSlice(cursor, fromDate, toDate):
     result = []
     for username in data:
         # doppler refers to cpu effiency as "cores" efficiency
-        # replace 0 eff values with '-' in output
-        # 0 eff values mean the job failed
         
         core_req = data[username]['ideal-cpu'];
         core_used = data[username]['cpu-time'];
@@ -176,20 +181,16 @@ def getTimeSlice(cursor, fromDate, toDate):
         time_used = data[username]['tlimit-use']
         time_eff = 100 * time_used / time_req if time_req != 0 else 0.0
 
-        cpuhours = None
+        try:
+            total_eff = sum([i for i in [core_eff, memory_eff, time_eff]]) / (3 - [core_eff, memory_eff, time_eff].count(0.0))
+        except:
+            total_eff = 0.0
         
-        if core_used == 0 and core_req == 0: # should only be True in single-core case
-            core_eff = time_eff
-            cpuhours = float(data[username]['tlimit-use']) / 3600
-        else:
-            cpuhours = float(data[username]['cpu-time']) / 3600
-
-        total_eff = (core_eff + memory_eff + time_eff) / 3
         result.append({'account'  : username,
                        'cores'    : round(core_eff, 2),
                        'memory'   : round(memory_eff, 2),
                        'time'     : round(time_eff, 2),
-                       'cpuhours' : round(cpuhours, 2),
+                       'core hours' : round(core_used / 3600.0, 2),
                        'total'    : round(total_eff, 2)})
 
     return result # returning a list to be sorted later
@@ -197,7 +198,7 @@ def getTimeSlice(cursor, fromDate, toDate):
 def main():
     parser = argparse.ArgumentParser(description="Get user efficiency statistics")
     parser.add_argument("-e", "--metric", type=str,
-                        choices=['cores', 'memory', 'time', 'total', 'cpuhours'],
+                        choices=['cores', 'memory', 'time', 'total', 'core hours'],
                         default='total', help="metric to sort by")
     parser.add_argument("-w", "--weekly", action="store_true",
                         help="select weekly time interval (default)")
@@ -257,16 +258,19 @@ def main():
     data = getTimeSlice(cursor, start_date, end_date)
 
     data.sort(key=lambda x: x['total'], reverse=True)
-    for i in range(len(data)): # rank is always based on total efficiency
-        # negating rank because unlike other metrics lower rank is good
-        data[i]['rank'] = -1 * (i + 1)
 
-    # using -1 * rank as a tie breaker
-    data.sort(key=operator.itemgetter(args.metric, 'rank'), reverse=not args.ascending)
-
-    # un-negating rank again
-    for i in range(len(data)):
-        data[i]['rank'] = -1 * data[i]['rank']
+    if not args.ascending:
+        for i in range(len(data)): # rank is always based on total efficiency
+            # negating rank because unlike other metrics lower rank is good
+            data[i]['rank'] = -1 * (i + 1)
+        data.sort(key=operator.itemgetter(args.metric, 'rank'), reverse=True)
+        # un-negating rank again
+        for i in range(len(data)):
+            data[i]['rank'] = -1 * data[i]['rank']
+    else:
+        for i in range(len(data)): # rank is always based on total efficiency
+            data[i]['rank'] = i + 1
+        data.sort(key=operator.itemgetter(args.metric, 'rank'), reverse=False)
 
     COLUMN_MAX         = config['DEFAULTS']['COLUMN_MAX']
     if(args.col_size is not None):


### PR DESCRIPTION
user_efficiency will now verbatim match doppler except for a couple edge cases. For one user_efficiency outputs "core hours" instead of "jobsum". This more closely represents usage. The other thing is that user_efficiency will break ties by rank # which you'll only notice if you use the "--ascending option" since you'll have a lot of 0 efficiency ties. There is likely no way to adjust this unless I copy all the doppler code since there are several rounds of stable sorting.

Example user_efficiency output:

```
jfg95@wind.nauhpc:~/hpc $ ./user_efficiency --metric cores -q
rank   account   cores    memory   time limit   core hours   total efficiency
===============================================================================
31     rgp3      130.37   12.8     0.25         27.5         47.81           
44     coc25     98.78    5.93     12.39        40.5K        39.04           
5      ksg225    98.4     78.1     44.15        120.5K       73.55           
47     ap2882    97.03    1.23     11.63        144.1        36.63           
33     ham232    96.41    1.83     35.38        14.4K        44.54           
15     gel35     93.94    3.52     66.72        702.2        54.73           
35     top23     91.14    29.41    8.34         23.2K        42.96           
27     af2289    89.65    2.96     53.21        5.7K         48.61           
14     sm3544    89.09    15.91    59.81        17.2K        54.94           
41     fl233     88.7     0.16     31.1         26.6         39.99           
jfg95@wind.nauhpc:~/hpc $ 
```

I have a copy of user_efficiency within ~/hpc/user_efficiency that you can use for testing.

Two ~1 line bug fixes:

1. group_efficiency: I initialize the "data" list variable higher up in the code to avoid the UnboundLocalError which repeatably occurs if you execute group_efficiency with an account name that has run no jobs for the time slice.

2. jobstats: If maxRSS is None I set it to '0.0' by default. It seems to yield None if you run "jobstats -r" just before a job completes. I have copied some output below.

current jobstats:
```
Requested Memory: 00.05%
Requested Cores : -
Time Limit      : 22.92%
=======================
Efficiency Score: 11.49
=======================
JobID             JobName                 ReqMem    MaxRSS    ReqCPUS   UserCPU     Timelimit   Elapsed    State       JobEff  
===============================================================================================================================
29617478          assignment5-act1-test   182.G     0.0M      1         00:00.181   00:02:00    00:00:12   COMPLETED   10.0   
29617535          assignment5-act1-test   182.G     0.84M     1         00:00.181   00:02:00    00:00:11   COMPLETED   4.58   
29617545          assignment5-act1-test   182.G     0.0M      1         00:00.183   00:02:00    00:00:02   COMPLETED   1.67   
29617547          assignment5-act1-test   182.G     0.0M      1         00:00.182   00:02:00    00:00:01   COMPLETED   0.83   
29617598          assignment5-act1-test   182.G     0.0M      1         00:00.189   00:02:00    00:00:03   COMPLETED   2.5   
29617603          assignment5-act1-test   182.G     240M      1         00:51.230   00:02:00    00:00:53   COMPLETED   22.15   
29617617          assignment5-act1-test   182.G     240M      1         00:30.941   00:02:00    00:00:33   COMPLETED   13.81   
29617657          assignment5-act1-test   182.G     240M      1         00:51.351   00:02:00    00:00:59   COMPLETED   24.65   
29617665          assignment5-act1-test   182.G     240M      1         00:51.313   00:02:00    00:00:54   COMPLETED   22.56   
29617763          assignment5-act1-test   182.G     3.42M     1         00:00.000   00:02:00    00:00:53   RUNNING     22.08     
===============================================================================================================================

Requested Memory: 00.05%
Requested Cores : -
Time Limit      : 23.42%
=======================
Efficiency Score: 11.74
=======================
JobID             JobName                 ReqMem    MaxRSS    ReqCPUS   UserCPU     Timelimit   Elapsed    State       JobEff  
===============================================================================================================================
29617478          assignment5-act1-test   182.G     0.0M      1         00:00.181   00:02:00    00:00:12   COMPLETED   10.0   
29617535          assignment5-act1-test   182.G     0.84M     1         00:00.181   00:02:00    00:00:11   COMPLETED   4.58   
29617545          assignment5-act1-test   182.G     0.0M      1         00:00.183   00:02:00    00:00:02   COMPLETED   1.67   
29617547          assignment5-act1-test   182.G     0.0M      1         00:00.182   00:02:00    00:00:01   COMPLETED   0.83   
29617598          assignment5-act1-test   182.G     0.0M      1         00:00.189   00:02:00    00:00:03   COMPLETED   2.5   
29617603          assignment5-act1-test   182.G     240M      1         00:51.230   00:02:00    00:00:53   COMPLETED   22.15   
29617617          assignment5-act1-test   182.G     240M      1         00:30.941   00:02:00    00:00:33   COMPLETED   13.81   
29617657          assignment5-act1-test   182.G     240M      1         00:51.351   00:02:00    00:00:59   COMPLETED   24.65   
29617665          assignment5-act1-test   182.G     240M      1         00:51.313   00:02:00    00:00:54   COMPLETED   22.56   
Traceback (most recent call last):
  File "/common/bin/jobstats", line 705, in <module>
    main()
  File "/common/bin/jobstats", line 440, in main
    maxRSS = maxRSS.replace(letter, '') 
AttributeError: 'NoneType' object has no attribute 'replace'
```
With None check (notice how MaxRSS is 0 here instead of throwing an error):
```
JobID             JobName                 ReqMem    MaxRSS    ReqCPUS   UserCPU     Timelimit   Elapsed    State       JobEff  
===============================================================================================================================
29617478          assignment5-act1-test   182.G     0.0M      1         00:00.181   00:02:00    00:00:12   COMPLETED   10.0   
29617535          assignment5-act1-test   182.G     0.84M     1         00:00.181   00:02:00    00:00:11   COMPLETED   4.58   
29617545          assignment5-act1-test   182.G     0.0M      1         00:00.183   00:02:00    00:00:02   COMPLETED   1.67   
29617547          assignment5-act1-test   182.G     0.0M      1         00:00.182   00:02:00    00:00:01   COMPLETED   0.83   
29617598          assignment5-act1-test   182.G     0.0M      1         00:00.189   00:02:00    00:00:03   COMPLETED   2.5   
29617603          assignment5-act1-test   182.G     240M      1         00:51.230   00:02:00    00:00:53   COMPLETED   22.15   
29617617          assignment5-act1-test   182.G     240M      1         00:30.941   00:02:00    00:00:33   COMPLETED   13.81   
29617657          assignment5-act1-test   182.G     240M      1         00:51.351   00:02:00    00:00:59   COMPLETED   24.65   
29617665          assignment5-act1-test   182.G     240M      1         00:51.313   00:02:00    00:00:54   COMPLETED   22.56   
29617763          assignment5-act1-test   182.G     3.42M     1         00:00.000   00:02:00    00:00:53   RUNNING     22.08     
===============================================================================================================================

Requested Memory: 00.05%
Requested Cores : -
Time Limit      : 23.42%
=======================
Efficiency Score: 11.74
=======================
JobID             JobName                 ReqMem    MaxRSS    ReqCPUS   UserCPU     Timelimit   Elapsed    State       JobEff  
===============================================================================================================================
29617478          assignment5-act1-test   182.G     0.0M      1         00:00.181   00:02:00    00:00:12   COMPLETED   10.0   
29617535          assignment5-act1-test   182.G     0.84M     1         00:00.181   00:02:00    00:00:11   COMPLETED   4.58   
29617545          assignment5-act1-test   182.G     0.0M      1         00:00.183   00:02:00    00:00:02   COMPLETED   1.67   
29617547          assignment5-act1-test   182.G     0.0M      1         00:00.182   00:02:00    00:00:01   COMPLETED   0.83   
29617598          assignment5-act1-test   182.G     0.0M      1         00:00.189   00:02:00    00:00:03   COMPLETED   2.5   
29617603          assignment5-act1-test   182.G     240M      1         00:51.230   00:02:00    00:00:53   COMPLETED   22.15   
29617617          assignment5-act1-test   182.G     240M      1         00:30.941   00:02:00    00:00:33   COMPLETED   13.81   
29617657          assignment5-act1-test   182.G     240M      1         00:51.351   00:02:00    00:00:59   COMPLETED   24.65   
29617665          assignment5-act1-test   182.G     240M      1         00:51.313   00:02:00    00:00:54   COMPLETED   22.56   
29617763          assignment5-act1-test   182.G     0.0M      1         21350398+   00:02:00    00:00:59   RUNNING     49.17     
===============================================================================================================================

Requested Memory: 00.05%
Requested Cores : -
Time Limit      : 23.92%
=======================
Efficiency Score: 11.99
=======================
```